### PR TITLE
Add return value on extended method in units.i.

### DIFF
--- a/src/bindings/interface/units.i
+++ b/src/bindings/interface/units.i
@@ -43,7 +43,7 @@
 // method removeUnit(ref) and telling swig not to use removeUnit(reference).
 %extend libcellml::Units {
     bool removeUnit(const std::string &ref) {
-        $self->removeUnit(ref);
+        return $self->removeUnit(ref);
     }
 }
 %ignore libcellml::Units::removeUnit(const std::string &reference);


### PR DESCRIPTION
Fixes issue for building on OS X see discussion on cellml/libcellml#161.