### PR TITLE
Add typemap for checking the values of the enum.

### DIFF
--- a/src/bindings/interface/units.i
+++ b/src/bindings/interface/units.i
@@ -29,10 +29,22 @@
     %extend libcellml::Units {
         bool removeUnit(long index) {
             if(index < 0) return false;
-            return $self->removeUnit(size_t(index));
+            return $self->removeUnit(static_cast<size_t>(index));
         }
     }
 #endif
+
+%typemap(in) libcellml::Prefix prefix (int val, int ecode) {
+  ecode = SWIG_AsVal(int)($input, &val);
+  if (!SWIG_IsOK(ecode)) {
+    %argument_fail(ecode, "$type", $symname, $argnum);
+  } else {
+    if (val < %static_cast(libcellml::Prefix::YOTTA, int) || %static_cast(libcellml::Prefix::YOCTO, int) < val) {
+      %argument_fail(ecode, "$type is not a valid value for the enumeration.", $symname, $argnum);
+    }
+    $1 = %static_cast(val,$basetype);
+  }
+}
 
 %feature("docstring") libcellml::Units
 "Represents a CellML Units definition.";


### PR DESCRIPTION
The current ability to throw any int into a method that is expecting an enumeration is a problem for C++.  It seems the standard currently defines casting to a value outside the value of an enumeration as resulting in a value that is unspecified.  Not very helpful, but in the future this will be changed and will result in undefined behaviour.  So letting this go unchecked is not going to be an option.

Here I have checked the Prefix enum but others would be similar, painful maintenance but they shouldn't change.